### PR TITLE
Protected route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,7 +20,8 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <ProtectedRoute path="/dashboard">
+                <Route exact path="/demo" component={Dashboard} />
+                <ProtectedRoute exact path="/dashboard">
                   <Dashboard />
                 </ProtectedRoute>
               </Switch>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,13 +1,13 @@
 import { MuiThemeProvider } from '@material-ui/core';
 import { theme } from './themes/theme';
-import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
-
+import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 import './App.css';
 
 function App(): JSX.Element {
@@ -20,12 +20,9 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard">
+                <ProtectedRoute path="/dashboard">
                   <Dashboard />
-                </Route>
-                <Route path="*">
-                  <Redirect to="/login" />
-                </Route>
+                </ProtectedRoute>
               </Switch>
             </SocketProvider>
           </AuthProvider>

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -4,8 +4,11 @@ import { Route, Redirect } from 'react-router-dom';
 type Props = {
   children: JSX.Element;
   path: string;
+  exact: boolean;
 };
 const ProtectedRoute: React.FC<Props> = ({ children, ...restOfProps }) => {
-  return <Route {...restOfProps} render={() => (true ? children : <Redirect to="/login" />)} />;
+  const { loggedInUser } = useAuth();
+
+  return <Route {...restOfProps} render={() => (Boolean(loggedInUser) ? children : <Redirect to="/login" />)} />;
 };
 export default ProtectedRoute;

--- a/client/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useAuth } from '../../context/useAuthContext';
+import { Route, Redirect } from 'react-router-dom';
+type Props = {
+  children: JSX.Element;
+  path: string;
+};
+const ProtectedRoute: React.FC<Props> = ({ children, ...restOfProps }) => {
+  return <Route {...restOfProps} render={() => (true ? children : <Redirect to="/login" />)} />;
+};
+export default ProtectedRoute;


### PR DESCRIPTION
Created a protected route component

### What this PR does:
- Stops users from accessing private pages unless they have been authenticated by the system

### Screenshots / Videos:
- 
![protectedRoute](https://user-images.githubusercontent.com/87187530/129227471-90ed815d-19bd-4725-abed-531d55e08f61.PNG)


### Any information needed to test this feature:
-The Dashboard route was used to Test this feature, try to visit the '/dashboard' route
-Pen the console and check whether the useEffect(ComponentDidMount) hook of the private component has ran
-A user is logged in by default, you can change the login status in the protected route component

### Any issues with the current functionality (optional):
- The protected page renders for loggedIn users. However, a user gets redirected to the login page on failed connection
